### PR TITLE
Sql server to sqlite migration

### DIFF
--- a/TaskManager.sln.DotSettings.user
+++ b/TaskManager.sln.DotSettings.user
@@ -1,2 +1,2 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeInspection/Highlighting/AnalysisEnabled/@EntryValue">SOLUTION</s:String></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeInspection/Roslyn/RoslynEnabled/@EntryValue">False</s:Boolean></wpf:ResourceDictionary>

--- a/TaskManagerAPI/Data/Database/ExistingTaskManagerDB.sql
+++ b/TaskManagerAPI/Data/Database/ExistingTaskManagerDB.sql
@@ -1,6 +1,0 @@
-﻿IF EXISTS (SELECT 1
-           FROM sys.databases
-           WHERE name = N'TaskManagerDB')
-    SELECT 1
-ELSE
-    SELECT 0;

--- a/TaskManagerAPI/Data/Database/Tables/create_tables.sql
+++ b/TaskManagerAPI/Data/Database/Tables/create_tables.sql
@@ -1,37 +1,37 @@
 ﻿-- Users Table
 CREATE TABLE Users (
-                       UserId INT PRIMARY KEY IDENTITY(1,1),
-                       Username NVARCHAR(255) NOT NULL,
-                       Email NVARCHAR(255) NOT NULL,
-                       Password NVARCHAR(255) NOT NULL
+                       UserId INTEGER PRIMARY KEY AUTOINCREMENT,
+                       Username TEXT NOT NULL,
+                       Email TEXT NOT NULL,
+                       Password TEXT NOT NULL
 );
 
 -- Tasks Table
 CREATE TABLE Tasks (
-                       TaskId INT PRIMARY KEY IDENTITY(1,1),
-                       UserId INT,
-                       Title NVARCHAR(255) NOT NULL,
-                       Description NVARCHAR(MAX),
-                       Created_at DATETIME2 DEFAULT GETDATE(),
-                       Completed BIT,
+                       TaskId INTEGER PRIMARY KEY AUTOINCREMENT,
+                       UserId INTEGER,
+                       Title TEXT NOT NULL,
+                       Description TEXT,
+                       Created_at DATETIME DEFAULT (datetime('now','localtime')),
+                       Completed INTEGER,
                        FOREIGN KEY (UserId) REFERENCES Users(UserId)
 );
 
 -- Subtasks Table
 CREATE TABLE Subtasks (
-                          SubtaskId INT PRIMARY KEY IDENTITY(1,1),
-                          TaskId INT,
-                          Title NVARCHAR(255) NOT NULL,
-                          Completed BIT,
+                          SubtaskId INTEGER PRIMARY KEY AUTOINCREMENT,
+                          TaskId INTEGER,
+                          Title TEXT NOT NULL,
+                          Completed INTEGER,
                           FOREIGN KEY (TaskId) REFERENCES Tasks(TaskId)
 );
 
 -- Sessions Table
 CREATE TABLE Sessions (
-                          Session_id INT PRIMARY KEY IDENTITY(1,1),
-                          TaskId INT,
-                          StartTime DATETIME2,
-                          EndTime DATETIME2,
-                          Duration INT,
+                          SessionId INTEGER PRIMARY KEY AUTOINCREMENT,
+                          TaskId INTEGER,
+                          StartTime DATETIME,
+                          EndTime DATETIME,
+                          Duration INTEGER,
                           FOREIGN KEY (TaskId) REFERENCES Tasks(TaskId)
 );

--- a/TaskManagerAPI/Data/Database/TaskManagerDB.sql
+++ b/TaskManagerAPI/Data/Database/TaskManagerDB.sql
@@ -1,4 +1,0 @@
-IF NOT EXISTS (SELECT name
-               FROM sys.databases
-               WHERE name = N'TaskManagerDB')
-CREATE DATABASE TaskManagerDB

--- a/TaskManagerAPI/Data/Providers/UserProvider.cs
+++ b/TaskManagerAPI/Data/Providers/UserProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System.Data.SqlClient;
 using Dapper;
+using Microsoft.Data.Sqlite;
 using TaskManagerAPI.Models;
 
 namespace TaskManagerAPI.Data.Providers;
@@ -23,7 +24,7 @@ public class UserProvider:IUserProvider
     {
         string sql = "SELECT UserID, Username, Email, Password FROM Users WHERE Username=@Username";
         
-        using var connection = new SqlConnection(_connectionString);
+        using var connection = new SqliteConnection(_connectionString);
         var user = connection.Query<User>(sql, new {Username = username}); 
         return user;
     }
@@ -32,7 +33,7 @@ public class UserProvider:IUserProvider
     {
         string sql = "Insert into Users (Username, Email, Password) values(@Username, @Email, @Password)";
 
-        using var connection = new SqlConnection(_connectionString);
+        using var connection = new SqliteConnection(_connectionString);
         var result = connection.Execute(sql, new {Username = user.Username, Email=user.Email, Password=user.Password});
     }
 
@@ -40,7 +41,7 @@ public class UserProvider:IUserProvider
     {
         string sql = "SELECT UserID FROM Users WHERE Username=@Username";
 
-        using var connection = new SqlConnection(_connectionString);
+        using var connection = new SqliteConnection(_connectionString);
         int id = connection.Query<int>(sql, new { Username = username }).FirstOrDefault();
 
         return id > 0;

--- a/TaskManagerAPI/TaskManagerAPI.csproj
+++ b/TaskManagerAPI/TaskManagerAPI.csproj
@@ -10,6 +10,7 @@
         <PackageReference Include="Dapper" Version="2.0.151" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.11" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.11"/>
+        <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.11" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
         <PackageReference Include="System.Data.SqlClient" Version="4.8.5"/>
     </ItemGroup>

--- a/TaskManagerAPI/appsettings.json
+++ b/TaskManagerAPI/appsettings.json
@@ -7,8 +7,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "AdminConnection": "Server=.;User Id=tm;Password=Taskmanager@123;",
-    "DefaultConnection": "Server=.;Database=TaskManagerDB;User Id=tm;Password=Taskmanager@123;"
+    "DefaultConnection": "Data Source=Data/Database/TaskManager.db"
   },
   "Jwt": {
     "Key": "TfzMpdK+6bclk5RoG9uW4ohni3yV+ZWq/WlQMe9M1Hep+Ati5IoGeubBHidx8A8E",


### PR DESCRIPTION
Updated db from SQL server to SQLite

Reason
1. SQL server is costly to deploy both in terms of server charge and licensing
2. Installing SQL server for development is hard especially in Linux based OS. Also it needs a good amount of system resources
3. Deployment is easier and quick. only one cloud instance is needed
4. Sq-lite perfectly meet all the requirements since this is a small project.